### PR TITLE
http_build_query incorrectly encodes spaces

### DIFF
--- a/ss-ga.class.php
+++ b/ss-ga.class.php
@@ -64,13 +64,13 @@ class ssga {
 	 * @return string
 	 */
 	public function create_gif() {
-		$data = array();
+		$query = '';
 		foreach ( $this->data as $key => $item ) {
 			if ( $item !== null ) {
-				$data[$key] = $item;
+				$query .= rawurlencode($key) . "=" . rawurlencode($item) . '&';
 			}
 		}
-		return $this->tracking = self::GA_URL . '?' . http_build_query( $data );
+		return $this->tracking = self::GA_URL . '?' . $query;
 	}
 
 	/**


### PR DESCRIPTION
The http_build_query will encode a space as a plus sign. This should be encoded as %20, instead of "+". Encoding as a + will cause Google Analytics to display it as a plus sign.

By manually building the query string, we can use rawurlencode to do proper encoding of spaces.
